### PR TITLE
[FEATURE] Add support for (most) WooCommerce settings. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/vendor/
+composer.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,40 @@
+language: php
+
+branches:
+    only:
+        - main
+
+services:
+    - mysql
+
+cache:
+    directories:
+        - "/home/travis/.composer/cache"
+
+env:
+    global:
+        - PATH="$TRAVIS_BUILD_DIR/vendor/bin:$PATH"
+        - WP_CLI_BIN_DIR="$TRAVIS_BUILD_DIR/vendor/bin"
+        - WP_CLI_TEST_DBROOTUSER=root
+        - WP_CLI_TEST_DBROOTPASS=''
+        - WP_CLI_TEST_DBUSER=wp_cli_test
+        - WP_CLI_TEST_DBPASS=password1
+        - WP_CLI_TEST_DBHOST=127.0.0.1
+
+install:
+    - composer install
+    - composer prepare-tests
+
+script:
+    - composer behat || composer behat-rerun
+
+jobs:
+    include:
+        -   stage: lint
+            script:
+                - composer lint
+                - composer phpcs
+            env: BUILD=lint
+        -   stage: test
+            php: 7.4
+            env: WP_VERSION=latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,26 @@
+# Contribute
+
+Running and writing tests
+-------------------------
+
+Dictator WooCommerce uses functional tests, implemented using [Behat](http://behat.org) and leveraging WP-CLI's testing framework. They are located in the `features/` directory.
+
+Before running the functional tests, you'll need to provision the testing environment. 
+
+First make sure you have run composer with dev dependencies:
+
+`composer install`
+
+Then you'll need to export the following vars (update the values accordingly):
+
+`export WP_CLI_TEST_DBROOTUSER=root`
+`export WP_CLI_TEST_DBROOTPASS=root`
+`export WP_CLI_TEST_DBUSER=wp_cli_test`
+`export WP_CLI_TEST_DBPASS=password1`
+`export WP_CLI_TEST_DBHOST=localhost`
+
+Finally...
+----------
+
+Thanks! Hacking on Dictator should be fun. If you find any of this hard to figure
+out, let us know so we can improve our process or documentation!

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # WooCommerce state for Dictator
 
-## Installation
+## Installation
 
 `composer req boxuk/dictator-woocommerce`
 
@@ -11,12 +11,170 @@ Use in your dictator state yaml files as such:
 ```yaml
 state: site
    # ...
-woocommerce:
+woocommerce-general:
   store_address: 2 Some Street
   store_address_2:
   store_city: some town
   default_country: GB
-  store_postcode: G1 3SJ
+  store_postcode: CF10 1XX
   allowed_countries: specific
   specific_allowed_countries: [GB, US]
+# ...
+woocommerce-advanced:
+  cart_page_id: 10
+  checkout_page_id: 20
+  myaccount_page_id: 30
+  terms_page_id: 40
+  force_ssl_checkout: true
 ```
+
+Or as part of a network:
+
+```yaml
+state: network
+   # ...
+sites:
+  :
+    title: Site one
+    active_plugins:
+        - woocommerce/woocommerce.php    
+    # ...
+    woocommerce-general:
+      store_address: 2 Some Street
+      store_address_2:
+      store_city: some town
+      default_country: GB
+      store_postcode: CF10 1XX
+      allowed_countries: specific
+      specific_allowed_countries: [GB, US]
+    # ...
+    woocommerce-advanced:
+        cart_page_id: 10
+        checkout_page_id: 20
+        myaccount_page_id: 30
+        terms_page_id: 40
+        force_ssl_checkout: true
+```
+
+## Supported settings
+
+* `woocommerce-general`
+    * `store_address`
+    * `store_address_2`
+    * `store_city`
+    * `default_country`
+    * `store_postcode`
+    * `allowed_countries`
+    * `specific_allowed_countries`
+    * `ship_to_countries`
+    * `specific_ship_to_countries`
+    * `default_customer_address`
+    * `calc_taxes`
+    * `enable_coupons`
+    * `calc_discounts_sequentially`
+    * `currency`
+    * `currency_pos`
+    * `price_thousand_sep`
+    * `price_decimal_sep`
+    * `price_num_decimals`
+* `woocommerce-product`
+    * `shop_page_id`
+    * `cart_redirect_after_add`
+    * `enable_ajax_add_to_cart`
+    * `placeholder_image`
+    * `weight_unit`
+    * `dimension_unit`
+    * `enable_reviews`
+    * `review_rating_verification_label`
+    * `review_rating_verification_required`
+    * `enable_review_rating`
+    * `review_rating_required`
+    * `manage_stock`
+    * `hold_stock_minutes`
+    * `notify_low_stock`
+    * `notify_no_stock`
+    * `stock_email_recipient`
+    * `notify_low_stock_amount`
+    * `notify_no_stock_amount`
+    * `hide_out_of_stock_items`
+    * `stock_format`
+    * `file_download_method`
+    * `downloads_require_login`
+    * `downloads_grant_access_after_payment`
+    * `downloads_add_hash_to_filename`
+* `woocommerce-tax`
+    * `prices_include_tax`
+    * `tax_based_on`
+    * `shipping_tax_class`
+    * `tax_round_at_subtotal`
+    * `tax_classes`
+    * `tax_display_shop`
+    * `tax_display_cart`
+    * `price_display_suffix`
+    * `tax_total_display`
+* `woocommerce-shipping`
+    * `enable_shipping_calc`
+    * `shipping_cost_requires_address`
+    * `ship_to_destination`
+    * `shipping_debug_mode`
+* `woocommerce-accounts`
+    * `enable_guest_checkout`
+    * `enable_checkout_login_reminder`
+    * `enable_signup_and_login_from_checkout`
+    * `enable_myaccount_registration`
+    * `registration_generate_username`
+    * `registration_generate_password`
+    * `erasure_request_removes_order_data`
+    * `erasure_request_removes_download_data`
+    * `allow_bulk_remove_personal_data`
+    * `registration_privacy_policy_text`
+    * `checkout_privacy_policy_text`
+    * `delete_inactive_accounts`
+    * `trash_pending_orders`
+    * `trash_failed_orders`
+    * `trash_cancelled_orders`
+    * `anonymize_completed_orders`
+* `woocommerce-email`
+    * `email_from_name`
+    * `email_from_address`
+    * `email_header_image`
+    * `email_footer_text`
+    * `email_base_color`
+    * `email_background_color`
+    * `email_body_background_color`
+    * `email_text_color`
+    * `merchant_email_notifications`
+* `woocommerce-advanced`
+    * `cart_page_id`
+    * `checkout_page_id`
+    * `myaccount_page_id`
+    * `terms_page_id`
+    * `force_ssl_checkout`
+    * `unforce_ssl_checkout`
+    * `checkout_pay_endpoint`
+    * `checkout_order_received_endpoint`
+    * `myaccount_add_payment_method_endpoint`
+    * `myaccount_delete_payment_method_endpoint`
+    * `myaccount_set_default_payment_method_endpoint`
+    * `myaccount_orders_endpoint`
+    * `myaccount_view_order_endpoint`
+    * `myaccount_downloads_endpoint`
+    * `myaccount_edit_account_endpoint`
+    * `myaccount_edit_address_endpoint`
+    * `myaccount_payment_methods_endpoint`
+    * `myaccount_lost_password_endpoint`
+    * `logout_endpoint`
+    * `api_enabled`
+    * `allow_tracking`
+    * `show_marketplace_suggestions`
+
+## Unsupported settings
+
+Some settings aren't supported, and will need to be configured by other means. These are listed below:
+
+* Tax rates
+* Shipping zones
+* Payment methods
+* Email notifications
+* REST API
+* Webhooks

--- a/behat.yml
+++ b/behat.yml
@@ -1,0 +1,7 @@
+default:
+  suites:
+    default:
+      contexts:
+        - WP_CLI\Tests\Context\FeatureContext
+      paths:
+        - features

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,42 @@
+{
+    "name": "boxuk/dictator-woocommerce",
+    "description": "WooCommerce state for Dictator",
+    "authors": [
+        {
+            "name" : "Box UK",
+            "email": "developers@boxuk.com",
+            "homepage": "https://www.boxuk.com"
+        }
+    ],
+    "type": "library",
+    "license": "MIT",
+    "minimum-stability": "dev",
+    "prefer-stable": true,
+    "require": {
+        "php": "^7.2",
+        "boxuk/dictator": "^0.2"
+    },
+    "autoload": {
+        "files": [ "dictator-woocommerce.php" ],
+        "psr-4": {
+            "BoxUk\\DictatorWooCommerce\\": "src/"
+        }
+    },
+    "require-dev": {
+        "wp-cli/wp-cli-bundle": "^2.4"
+    },
+    "scripts": {
+        "behat": "run-behat-tests",
+        "behat-rerun": "rerun-behat-tests",
+        "lint": "run-linter-tests",
+        "phpcs": "run-phpcs-tests",
+        "phpunit": "run-php-unit-tests",
+        "prepare-tests": "install-package-tests",
+        "test": [
+            "@lint",
+            "@phpcs",
+            "@phpunit",
+            "@behat"
+        ]
+    }
+}

--- a/dictator-woocommerce.php
+++ b/dictator-woocommerce.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Add WooCommerce region to Dictator.
+ */
+
+use BoxUk\DictatorWooCommerce\State\WoocommerceNetwork;
+use BoxUk\DictatorWooCommerce\State\WoocommerceSite;
+
+if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
+	return;
+}
+
+if ( ! class_exists( WoocommerceSite::class ) ) {
+	require_once __DIR__ . '/vendor/autoload.php';
+}
+
+// Note this will overwrite the default site and network states, so it's important ours include the defaults too.
+Dictator::add_state( 'site', WoocommerceSite::class );
+Dictator::add_state( 'network', WoocommerceNetwork::class );

--- a/features/load-wp-cli.feature
+++ b/features/load-wp-cli.feature
@@ -1,0 +1,10 @@
+Feature: Test that WP-CLI loads.
+
+  Scenario: WP-CLI loads for your tests
+    Given a WP install
+
+    When I run `wp eval 'echo "Hello world.";'`
+    Then STDOUT should contain:
+      """
+      Hello world.
+      """

--- a/features/woocommerce-accounts-network-settings.feature
+++ b/features/woocommerce-accounts-network-settings.feature
@@ -1,0 +1,142 @@
+Feature: WooCommerce Network Accounts Settings Region
+
+  Scenario: Impose Accounts WooCommerce Network Settings
+    Given a WP multisite install
+    And a woocommerce-network.yml file:
+      """
+      state: network
+      sites:
+        siteone:
+          title: Site one
+          active_plugins:
+            - woocommerce/woocommerce.php
+          woocommerce-accounts:
+            enable_guest_checkout: true
+            enable_checkout_login_reminder: false
+            enable_signup_and_login_from_checkout: true
+            enable_myaccount_registration: true
+            registration_generate_username: true
+            registration_generate_password: true
+            erasure_request_removes_order_data: true
+            erasure_request_removes_download_data: true
+            allow_bulk_remove_personal_data: true
+            registration_privacy_policy_text: We use cookies
+            checkout_privacy_policy_text: We use cookies
+            delete_inactive_accounts:
+              number: 30
+              unit: days
+            trash_pending_orders:
+              number: 5
+              unit: days
+            trash_failed_orders:
+              number: 10
+              unit: days
+            trash_cancelled_orders:
+              number: 1
+              unit: weeks
+            anonymize_completed_orders:
+              number: 1
+              unit: months
+      """
+
+    When I run `wp dictator impose woocommerce-network.yml`
+    Then STDOUT should not be empty
+
+    When I run `wp dictator compare woocommerce-network.yml`
+    Then STDOUT should be empty
+
+    When I run `wp --url=example.com/siteone option get woocommerce_enable_guest_checkout`
+    Then STDOUT should be:
+      """
+      yes
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_enable_checkout_login_reminder`
+    Then STDOUT should be:
+      """
+      no
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_enable_signup_and_login_from_checkout`
+    Then STDOUT should be:
+      """
+      yes
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_enable_myaccount_registration`
+    Then STDOUT should be:
+      """
+      yes
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_registration_generate_username`
+    Then STDOUT should be:
+      """
+      yes
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_registration_generate_password`
+    Then STDOUT should be:
+      """
+      yes
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_erasure_request_removes_order_data`
+    Then STDOUT should be:
+      """
+      yes
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_erasure_request_removes_download_data`
+    Then STDOUT should be:
+      """
+      yes
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_allow_bulk_remove_personal_data`
+    Then STDOUT should be:
+      """
+      yes
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_registration_privacy_policy_text`
+    Then STDOUT should be:
+      """
+      We use cookies
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_checkout_privacy_policy_text`
+    Then STDOUT should be:
+      """
+      We use cookies
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_delete_inactive_accounts --format=json`
+    Then STDOUT should be:
+      """
+      {"number":30,"unit":"days"}
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_trash_pending_orders --format=json`
+    Then STDOUT should be:
+      """
+      {"number":5,"unit":"days"}
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_trash_failed_orders --format=json`
+    Then STDOUT should be:
+      """
+      {"number":10,"unit":"days"}
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_trash_cancelled_orders --format=json`
+    Then STDOUT should be:
+      """
+      {"number":1,"unit":"weeks"}
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_anonymize_completed_orders --format=json`
+    Then STDOUT should be:
+      """
+      {"number":1,"unit":"months"}
+      """

--- a/features/woocommerce-accounts-site-settings.feature
+++ b/features/woocommerce-accounts-site-settings.feature
@@ -1,0 +1,142 @@
+Feature: WooCommerce Network Accounts Settings Region
+
+  Scenario: Impose Accounts WooCommerce Network Settings
+    Given a WP multisite install
+    And a woocommerce-network.yml file:
+      """
+      state: network
+      sites:
+        siteone:
+          title: Site one
+          active_plugins:
+            - woocommerce/woocommerce.php
+          woocommerce-accounts:
+            enable_guest_checkout: true
+            enable_checkout_login_reminder: false
+            enable_signup_and_login_from_checkout: true
+            enable_myaccount_registration: true
+            registration_generate_username: true
+            registration_generate_password: true
+            erasure_request_removes_order_data: true
+            erasure_request_removes_download_data: true
+            allow_bulk_remove_personal_data: true
+            registration_privacy_policy_text: We use cookies
+            checkout_privacy_policy_text: We use cookies
+            delete_inactive_accounts:
+              number: 30
+              unit: days
+            trash_pending_orders:
+              number: 5
+              unit: days
+            trash_failed_orders:
+              number: 10
+              unit: days
+            trash_cancelled_orders:
+              number: 1
+              unit: weeks
+            anonymize_completed_orders:
+              number: 1
+              unit: months
+      """
+
+    When I run `wp dictator impose woocommerce-network.yml`
+    Then STDOUT should not be empty
+
+    When I run `wp dictator compare woocommerce-network.yml`
+    Then STDOUT should be empty
+
+    When I run `wp --url=example.com/siteone option get woocommerce_enable_guest_checkout`
+    Then STDOUT should be:
+      """
+      yes
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_enable_checkout_login_reminder`
+    Then STDOUT should be:
+      """
+      no
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_enable_signup_and_login_from_checkout`
+    Then STDOUT should be:
+      """
+      yes
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_enable_myaccount_registration`
+    Then STDOUT should be:
+      """
+      yes
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_registration_generate_username`
+    Then STDOUT should be:
+      """
+      yes
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_registration_generate_password`
+    Then STDOUT should be:
+      """
+      yes
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_erasure_request_removes_order_data`
+    Then STDOUT should be:
+      """
+      yes
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_erasure_request_removes_download_data`
+    Then STDOUT should be:
+      """
+      yes
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_allow_bulk_remove_personal_data`
+    Then STDOUT should be:
+      """
+      yes
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_registration_privacy_policy_text`
+    Then STDOUT should be:
+      """
+      We use cookies
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_checkout_privacy_policy_text`
+    Then STDOUT should be:
+      """
+      We use cookies
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_delete_inactive_accounts --format=json`
+    Then STDOUT should be:
+      """
+      {"number":30,"unit":"days"}
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_trash_pending_orders --format=json`
+    Then STDOUT should be:
+      """
+      {"number":5,"unit":"days"}
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_trash_failed_orders --format=json`
+    Then STDOUT should be:
+      """
+      {"number":10,"unit":"days"}
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_trash_cancelled_orders --format=json`
+    Then STDOUT should be:
+      """
+      {"number":1,"unit":"weeks"}
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_anonymize_completed_orders --format=json`
+    Then STDOUT should be:
+      """
+      {"number":1,"unit":"months"}
+      """

--- a/features/woocommerce-advanced-network-settings.feature
+++ b/features/woocommerce-advanced-network-settings.feature
@@ -1,0 +1,174 @@
+Feature: WooCommerce Network Advanced Settings Region
+
+  Scenario: Impose Advanced WooCommerce Network Settings
+    Given a WP multisite install
+    And a woocommerce-network.yml file:
+      """
+      state: network
+      sites:
+        siteone:
+          title: Site one
+          active_plugins:
+            - woocommerce/woocommerce.php
+          woocommerce-advanced:
+            cart_page_id: 1
+            checkout_page_id: 1
+            myaccount_page_id: 1
+            terms_page_id: 1
+            force_ssl_checkout: true
+            unforce_ssl_checkout: false
+            checkout_pay_endpoint: order-pay
+            checkout_order_received_endpoint: order-received
+            myaccount_add_payment_method_endpoint: add-payment-method
+            myaccount_delete_payment_method_endpoint: delete-payment-method
+            myaccount_set_default_payment_method_endpoint: set-default-payment-method
+            myaccount_orders_endpoint: orders
+            myaccount_view_order_endpoint: view-order
+            myaccount_downloads_endpoint: downloads
+            myaccount_edit_account_endpoint: edit-account
+            myaccount_edit_address_endpoint: edit-address
+            myaccount_payment_methods_endpoint: payment-methods
+            myaccount_lost_password_endpoint: lost-password
+            logout_endpoint: customer-logout
+            api_enabled: false
+            allow_tracking: false
+            show_marketplace_suggestions: false
+      """
+
+    When I run `wp dictator impose woocommerce-network.yml`
+    Then STDOUT should not be empty
+
+    When I run `wp dictator compare woocommerce-network.yml`
+    Then STDOUT should be empty
+
+    When I run `wp --url=example.com/siteone option get woocommerce_cart_page_id`
+    Then STDOUT should be:
+      """
+      1
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_checkout_page_id`
+    Then STDOUT should be:
+      """
+      1
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_myaccount_page_id`
+    Then STDOUT should be:
+      """
+      1
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_terms_page_id`
+    Then STDOUT should be:
+      """
+      1
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_force_ssl_checkout`
+    Then STDOUT should be:
+      """
+      yes
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_unforce_ssl_checkout`
+    Then STDOUT should be:
+      """
+      no
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_checkout_pay_endpoint`
+    Then STDOUT should be:
+      """
+      order-pay
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_checkout_order_received_endpoint`
+    Then STDOUT should be:
+      """
+      order-received
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_myaccount_add_payment_method_endpoint`
+    Then STDOUT should be:
+      """
+      add-payment-method
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_myaccount_delete_payment_method_endpoint`
+    Then STDOUT should be:
+      """
+      delete-payment-method
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_myaccount_set_default_payment_method_endpoint`
+    Then STDOUT should be:
+      """
+      set-default-payment-method
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_myaccount_orders_endpoint`
+    Then STDOUT should be:
+      """
+      orders
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_myaccount_view_order_endpoint`
+    Then STDOUT should be:
+      """
+      view-order
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_myaccount_downloads_endpoint`
+    Then STDOUT should be:
+      """
+      downloads
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_myaccount_edit_account_endpoint`
+    Then STDOUT should be:
+      """
+      edit-account
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_myaccount_edit_address_endpoint`
+    Then STDOUT should be:
+      """
+      edit-address
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_myaccount_payment_methods_endpoint`
+    Then STDOUT should be:
+      """
+      payment-methods
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_myaccount_lost_password_endpoint`
+    Then STDOUT should be:
+      """
+      lost-password
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_logout_endpoint`
+    Then STDOUT should be:
+      """
+      customer-logout
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_api_enabled`
+    Then STDOUT should be:
+      """
+      no
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_allow_tracking`
+    Then STDOUT should be:
+      """
+      no
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_show_marketplace_suggestions`
+    Then STDOUT should be:
+      """
+      no
+      """

--- a/features/woocommerce-advanced-site-settings.feature
+++ b/features/woocommerce-advanced-site-settings.feature
@@ -1,0 +1,169 @@
+Feature: WooCommerce Site Advanced Settings Region
+
+  Scenario: Impose Advanced WooCommerce Site Settings
+    Given a WP install
+    And a woocommerce.yml file:
+      """
+      state: site
+      woocommerce-advanced:
+        cart_page_id: 1
+        checkout_page_id: 1
+        myaccount_page_id: 1
+        terms_page_id: 1
+        force_ssl_checkout: true
+        unforce_ssl_checkout: false
+        checkout_pay_endpoint: order-pay
+        checkout_order_received_endpoint: order-received
+        myaccount_add_payment_method_endpoint: add-payment-method
+        myaccount_delete_payment_method_endpoint: delete-payment-method
+        myaccount_set_default_payment_method_endpoint: set-default-payment-method
+        myaccount_orders_endpoint: orders
+        myaccount_view_order_endpoint: view-order
+        myaccount_downloads_endpoint: downloads
+        myaccount_edit_account_endpoint: edit-account
+        myaccount_edit_address_endpoint: edit-address
+        myaccount_payment_methods_endpoint: payment-methods
+        myaccount_lost_password_endpoint: lost-password
+        logout_endpoint: customer-logout
+        api_enabled: false
+        allow_tracking: false
+        show_marketplace_suggestions: false
+      """
+
+    When I run `wp dictator impose woocommerce.yml`
+    Then STDOUT should not be empty
+
+    When I run `wp dictator compare woocommerce.yml`
+    Then STDOUT should be empty
+
+    When I run `wp option get woocommerce_cart_page_id`
+    Then STDOUT should be:
+      """
+      1
+      """
+
+    When I run `wp option get woocommerce_checkout_page_id`
+    Then STDOUT should be:
+      """
+      1
+      """
+
+    When I run `wp option get woocommerce_myaccount_page_id`
+    Then STDOUT should be:
+      """
+      1
+      """
+
+    When I run `wp option get woocommerce_terms_page_id`
+    Then STDOUT should be:
+      """
+      1
+      """
+
+    When I run `wp option get woocommerce_force_ssl_checkout`
+    Then STDOUT should be:
+      """
+      yes
+      """
+
+    When I run `wp option get woocommerce_unforce_ssl_checkout`
+    Then STDOUT should be:
+      """
+      no
+      """
+
+    When I run `wp option get woocommerce_checkout_pay_endpoint`
+    Then STDOUT should be:
+      """
+      order-pay
+      """
+
+    When I run `wp option get woocommerce_checkout_order_received_endpoint`
+    Then STDOUT should be:
+      """
+      order-received
+      """
+
+    When I run `wp option get woocommerce_myaccount_add_payment_method_endpoint`
+    Then STDOUT should be:
+      """
+      add-payment-method
+      """
+
+    When I run `wp option get woocommerce_myaccount_delete_payment_method_endpoint`
+    Then STDOUT should be:
+      """
+      delete-payment-method
+      """
+
+    When I run `wp option get woocommerce_myaccount_set_default_payment_method_endpoint`
+    Then STDOUT should be:
+      """
+      set-default-payment-method
+      """
+
+    When I run `wp option get woocommerce_myaccount_orders_endpoint`
+    Then STDOUT should be:
+      """
+      orders
+      """
+
+    When I run `wp option get woocommerce_myaccount_view_order_endpoint`
+    Then STDOUT should be:
+      """
+      view-order
+      """
+
+    When I run `wp option get woocommerce_myaccount_downloads_endpoint`
+    Then STDOUT should be:
+      """
+      downloads
+      """
+
+    When I run `wp option get woocommerce_myaccount_edit_account_endpoint`
+    Then STDOUT should be:
+      """
+      edit-account
+      """
+
+    When I run `wp option get woocommerce_myaccount_edit_address_endpoint`
+    Then STDOUT should be:
+      """
+      edit-address
+      """
+
+    When I run `wp option get woocommerce_myaccount_payment_methods_endpoint`
+    Then STDOUT should be:
+      """
+      payment-methods
+      """
+
+    When I run `wp option get woocommerce_myaccount_lost_password_endpoint`
+    Then STDOUT should be:
+      """
+      lost-password
+      """
+
+    When I run `wp option get woocommerce_logout_endpoint`
+    Then STDOUT should be:
+      """
+      customer-logout
+      """
+
+    When I run `wp option get woocommerce_api_enabled`
+    Then STDOUT should be:
+      """
+      no
+      """
+
+    When I run `wp option get woocommerce_allow_tracking`
+    Then STDOUT should be:
+      """
+      no
+      """
+
+    When I run `wp option get woocommerce_show_marketplace_suggestions`
+    Then STDOUT should be:
+      """
+      no
+      """

--- a/features/woocommerce-email-network-settings.feature
+++ b/features/woocommerce-email-network-settings.feature
@@ -1,0 +1,83 @@
+Feature: WooCommerce Network Email Settings Region
+
+  Scenario: Impose Email WooCommerce Network Settings
+    Given a WP multisite install
+    And a woocommerce-network.yml file:
+      """
+      state: network
+      sites:
+        siteone:
+          title: Site one
+          active_plugins:
+            - woocommerce/woocommerce.php
+          woocommerce-email:
+            email_from_name: Admin
+            email_from_address: example@example.com
+            email_header_image: foo.jpg
+            email_footer_text: Thanks for your custom
+            email_base_color: '#000000'
+            email_background_color: '#FFF'
+            email_body_background_color: '#FFF'
+            email_text_color: '#000'
+            merchant_email_notifications: false
+      """
+
+    When I run `wp dictator impose woocommerce-network.yml`
+    Then STDOUT should not be empty
+
+    When I run `wp dictator compare woocommerce-network.yml`
+    Then STDOUT should be empty
+
+    When I run `wp --url=example.com/siteone option get woocommerce_email_from_name`
+    Then STDOUT should be:
+      """
+      Admin
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_email_from_address`
+    Then STDOUT should be:
+      """
+      example@example.com
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_email_header_image`
+    Then STDOUT should be:
+      """
+      foo.jpg
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_email_footer_text`
+    Then STDOUT should be:
+      """
+      Thanks for your custom
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_email_base_color`
+    Then STDOUT should be:
+      """
+      #000000
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_email_background_color`
+    Then STDOUT should be:
+      """
+      #FFF
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_email_body_background_color`
+    Then STDOUT should be:
+      """
+      #FFF
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_email_text_color`
+    Then STDOUT should be:
+      """
+      #000
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_merchant_email_notifications`
+    Then STDOUT should be:
+      """
+      no
+      """

--- a/features/woocommerce-email-site-settings.feature
+++ b/features/woocommerce-email-site-settings.feature
@@ -1,0 +1,78 @@
+Feature: WooCommerce Site Email Settings Region
+
+  Scenario: Impose Email WooCommerce Site Settings
+    Given a WP install
+    And a woocommerce.yml file:
+      """
+      state: site
+      woocommerce-email:
+        email_from_name: Admin
+        email_from_address: example@example.com
+        email_header_image: foo.jpg
+        email_footer_text: Thanks for your custom
+        email_base_color: '#000000'
+        email_background_color: '#FFF'
+        email_body_background_color: '#FFF'
+        email_text_color: '#000'
+        merchant_email_notifications: false
+      """
+
+    When I run `wp dictator impose woocommerce.yml`
+    Then STDOUT should not be empty
+
+    When I run `wp dictator compare woocommerce.yml`
+    Then STDOUT should be empty
+
+    When I run `wp option get woocommerce_email_from_name`
+    Then STDOUT should be:
+      """
+      Admin
+      """
+
+    When I run `wp option get woocommerce_email_from_address`
+    Then STDOUT should be:
+      """
+      example@example.com
+      """
+
+    When I run `wp option get woocommerce_email_header_image`
+    Then STDOUT should be:
+      """
+      foo.jpg
+      """
+
+    When I run `wp option get woocommerce_email_footer_text`
+    Then STDOUT should be:
+      """
+      Thanks for your custom
+      """
+
+    When I run `wp option get woocommerce_email_base_color`
+    Then STDOUT should be:
+      """
+      #000000
+      """
+
+    When I run `wp option get woocommerce_email_background_color`
+    Then STDOUT should be:
+      """
+      #FFF
+      """
+
+    When I run `wp option get woocommerce_email_body_background_color`
+    Then STDOUT should be:
+      """
+      #FFF
+      """
+
+    When I run `wp option get woocommerce_email_text_color`
+    Then STDOUT should be:
+      """
+      #000
+      """
+
+    When I run `wp option get woocommerce_merchant_email_notifications`
+    Then STDOUT should be:
+      """
+      no
+      """

--- a/features/woocommerce-general-network-settings.feature
+++ b/features/woocommerce-general-network-settings.feature
@@ -1,0 +1,149 @@
+Feature: WooCommerce Network General Settings Region
+
+  Scenario: Impose General WooCommerce Network Settings
+    Given a WP multisite install
+    And a woocommerce-network.yml file:
+      """
+      state: network
+      sites:
+        siteone:
+          title: Site one
+          active_plugins:
+            - woocommerce/woocommerce.php
+          woocommerce-general:
+            store_address: 2 Some Street
+            store_address_2:
+            store_city: some town
+            default_country: GB
+            store_postcode: CF10 1XX
+            allowed_countries: specific
+            specific_allowed_countries:
+              - GB
+              - US
+            ship_to_countries: specific
+            specific_ship_to_countries:
+              - GB
+              - US
+            default_customer_address: base
+            calc_taxes: true
+            enable_coupons: false
+            calc_discounts_sequentially: true
+            currency: GBP
+            currency_pos: left
+            price_thousand_sep: ,
+            price_decimal_sep: .
+            price_num_decimals: 2
+      """
+
+    When I run `wp dictator impose woocommerce-network.yml`
+    Then STDOUT should not be empty
+
+    When I run `wp dictator compare woocommerce-network.yml`
+    Then STDOUT should be empty
+
+    When I run `wp --url=example.com/siteone option get woocommerce_store_address`
+    Then STDOUT should be:
+      """
+      2 Some Street
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_store_address_2`
+    Then STDOUT should be:
+      """
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_store_city`
+    Then STDOUT should be:
+      """
+      some town
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_default_country`
+    Then STDOUT should be:
+      """
+      GB
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_store_postcode`
+    Then STDOUT should be:
+      """
+      CF10 1XX
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_allowed_countries`
+    Then STDOUT should be:
+      """
+      specific
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_specific_allowed_countries --format=json`
+    Then STDOUT should be:
+      """
+      ["GB","US"]
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_ship_to_countries`
+    Then STDOUT should be:
+      """
+      specific
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_specific_ship_to_countries --format=json`
+    Then STDOUT should be:
+      """
+      ["GB","US"]
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_default_customer_address`
+    Then STDOUT should be:
+      """
+      base
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_calc_taxes`
+    Then STDOUT should be:
+      """
+      yes
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_enable_coupons`
+    Then STDOUT should be:
+      """
+      no
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_calc_discounts_sequentially`
+    Then STDOUT should be:
+      """
+      yes
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_currency`
+    Then STDOUT should be:
+      """
+      GBP
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_currency_pos`
+    Then STDOUT should be:
+      """
+      left
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_price_thousand_sep`
+    Then STDOUT should be:
+      """
+      ,
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_price_decimal_sep`
+    Then STDOUT should be:
+      """
+      .
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_price_num_decimals`
+    Then STDOUT should be:
+      """
+      2
+      """

--- a/features/woocommerce-general-site-settings.feature
+++ b/features/woocommerce-general-site-settings.feature
@@ -1,0 +1,144 @@
+Feature: WooCommerce Site General Settings Region
+
+  Scenario: Impose General WooCommerce Site Settings
+    Given a WP install
+    And a woocommerce.yml file:
+      """
+      state: site
+      woocommerce-general:
+        store_address: 2 Some Street
+        store_address_2:
+        store_city: some town
+        default_country: GB
+        store_postcode: CF10 1XX
+        allowed_countries: specific
+        specific_allowed_countries:
+          - GB
+          - US
+        ship_to_countries: specific
+        specific_ship_to_countries:
+          - GB
+          - US
+        default_customer_address: base
+        calc_taxes: true
+        enable_coupons: false
+        calc_discounts_sequentially: true
+        currency: GBP
+        currency_pos: left
+        price_thousand_sep: ,
+        price_decimal_sep: .
+        price_num_decimals: 2
+      """
+
+    When I run `wp dictator impose woocommerce.yml`
+    Then STDOUT should not be empty
+
+    When I run `wp dictator compare woocommerce.yml`
+    Then STDOUT should be empty
+
+    When I run `wp option get woocommerce_store_address`
+    Then STDOUT should be:
+      """
+      2 Some Street
+      """
+
+    When I run `wp option get woocommerce_store_address_2`
+    Then STDOUT should be:
+      """
+      """
+
+    When I run `wp option get woocommerce_store_city`
+    Then STDOUT should be:
+      """
+      some town
+      """
+
+    When I run `wp option get woocommerce_default_country`
+    Then STDOUT should be:
+      """
+      GB
+      """
+
+    When I run `wp option get woocommerce_store_postcode`
+    Then STDOUT should be:
+      """
+      CF10 1XX
+      """
+
+    When I run `wp option get woocommerce_allowed_countries`
+    Then STDOUT should be:
+      """
+      specific
+      """
+
+    When I run `wp option get woocommerce_specific_allowed_countries --format=json`
+    Then STDOUT should be:
+      """
+      ["GB","US"]
+      """
+
+    When I run `wp option get woocommerce_ship_to_countries`
+    Then STDOUT should be:
+      """
+      specific
+      """
+
+    When I run `wp option get woocommerce_specific_ship_to_countries --format=json`
+    Then STDOUT should be:
+      """
+      ["GB","US"]
+      """
+
+    When I run `wp option get woocommerce_default_customer_address`
+    Then STDOUT should be:
+      """
+      base
+      """
+
+    When I run `wp option get woocommerce_calc_taxes`
+    Then STDOUT should be:
+      """
+      yes
+      """
+
+    When I run `wp option get woocommerce_enable_coupons`
+    Then STDOUT should be:
+      """
+      no
+      """
+
+    When I run `wp option get woocommerce_calc_discounts_sequentially`
+    Then STDOUT should be:
+      """
+      yes
+      """
+
+    When I run `wp option get woocommerce_currency`
+    Then STDOUT should be:
+      """
+      GBP
+      """
+
+    When I run `wp option get woocommerce_currency_pos`
+    Then STDOUT should be:
+      """
+      left
+      """
+
+    When I run `wp option get woocommerce_price_thousand_sep`
+    Then STDOUT should be:
+      """
+      ,
+      """
+
+    When I run `wp option get woocommerce_price_decimal_sep`
+    Then STDOUT should be:
+      """
+      .
+      """
+
+    When I run `wp option get woocommerce_price_num_decimals`
+    Then STDOUT should be:
+      """
+      2
+      """

--- a/features/woocommerce-product-network-settings.feature
+++ b/features/woocommerce-product-network-settings.feature
@@ -1,0 +1,181 @@
+Feature: WooCommerce Network Product Settings Region
+
+  Scenario: Impose Product WooCommerce Network Settings
+    Given a WP multisite install
+    And a woocommerce-network.yml file:
+      """
+      state: network
+      sites:
+        siteone:
+          title: Site one
+          active_plugins:
+            - woocommerce/woocommerce.php
+          woocommerce-product:
+            shop_page_id: 1
+            cart_redirect_after_add: false
+            enable_ajax_add_to_cart: true
+            placeholder_image: foo.jpg
+            weight_unit: kg
+            dimension_unit: cm
+            enable_reviews: true
+            review_rating_verification_label: false
+            review_rating_verification_required: true
+            enable_review_rating: true
+            review_rating_required: false
+            manage_stock: true
+            hold_stock_minutes: 5
+            notify_low_stock: true
+            notify_no_stock: true
+            stock_email_recipient: example@example.com
+            notify_low_stock_amount: 5
+            notify_no_stock_amount: 0
+            hide_out_of_stock_items: false
+            stock_format:
+            file_download_method: redirect
+            downloads_require_login: true
+            downloads_grant_access_after_payment: true
+            downloads_add_hash_to_filename: true
+      """
+
+    When I run `wp dictator impose woocommerce-network.yml`
+    Then STDOUT should not be empty
+
+    When I run `wp dictator compare woocommerce-network.yml`
+    Then STDOUT should be empty
+
+    When I run `wp --url=example.com/siteone option get woocommerce_shop_page_id`
+    Then STDOUT should be:
+      """
+      1
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_cart_redirect_after_add`
+    Then STDOUT should be:
+      """
+      no
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_placeholder_image`
+    Then STDOUT should be:
+      """
+      foo.jpg
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_weight_unit`
+    Then STDOUT should be:
+      """
+      kg
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_dimension_unit`
+    Then STDOUT should be:
+      """
+      cm
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_enable_reviews`
+    Then STDOUT should be:
+      """
+      yes
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_review_rating_verification_label`
+    Then STDOUT should be:
+      """
+      no
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_review_rating_verification_required`
+    Then STDOUT should be:
+      """
+      yes
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_enable_review_rating`
+    Then STDOUT should be:
+      """
+      yes
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_review_rating_required`
+    Then STDOUT should be:
+      """
+      no
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_manage_stock`
+    Then STDOUT should be:
+      """
+      yes
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_hold_stock_minutes`
+    Then STDOUT should be:
+      """
+      5
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_notify_low_stock`
+    Then STDOUT should be:
+      """
+      yes
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_notify_no_stock`
+    Then STDOUT should be:
+      """
+      yes
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_stock_email_recipient`
+    Then STDOUT should be:
+      """
+      example@example.com
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_notify_low_stock_amount`
+    Then STDOUT should be:
+      """
+      5
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_notify_no_stock_amount`
+    Then STDOUT should be:
+      """
+      0
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_hide_out_of_stock_items`
+    Then STDOUT should be:
+      """
+      no
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_stock_format`
+    Then STDOUT should be:
+      """
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_file_download_method`
+    Then STDOUT should be:
+      """
+      redirect
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_downloads_require_login`
+    Then STDOUT should be:
+      """
+      yes
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_downloads_grant_access_after_payment`
+    Then STDOUT should be:
+      """
+      yes
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_downloads_add_hash_to_filename`
+    Then STDOUT should be:
+      """
+      yes
+      """

--- a/features/woocommerce-product-site-settings.feature
+++ b/features/woocommerce-product-site-settings.feature
@@ -1,0 +1,176 @@
+Feature: WooCommerce Site Product Settings Region
+
+  Scenario: Impose Product WooCommerce Site Settings
+    Given a WP install
+    And a woocommerce.yml file:
+      """
+      state: site
+      woocommerce-product:
+        shop_page_id: 1
+        cart_redirect_after_add: false
+        enable_ajax_add_to_cart: true
+        placeholder_image: foo.jpg
+        weight_unit: kg
+        dimension_unit: cm
+        enable_reviews: true
+        review_rating_verification_label: false
+        review_rating_verification_required: true
+        enable_review_rating: true
+        review_rating_required: false
+        manage_stock: true
+        hold_stock_minutes: 5
+        notify_low_stock: true
+        notify_no_stock: true
+        stock_email_recipient: example@example.com
+        notify_low_stock_amount: 5
+        notify_no_stock_amount: 0
+        hide_out_of_stock_items: false
+        stock_format:
+        file_download_method: redirect
+        downloads_require_login: true
+        downloads_grant_access_after_payment: true
+        downloads_add_hash_to_filename: true
+      """
+
+    When I run `wp dictator impose woocommerce.yml`
+    Then STDOUT should not be empty
+
+    When I run `wp dictator compare woocommerce.yml`
+    Then STDOUT should be empty
+
+    When I run `wp option get woocommerce_shop_page_id`
+    Then STDOUT should be:
+      """
+      1
+      """
+
+    When I run `wp option get woocommerce_cart_redirect_after_add`
+    Then STDOUT should be:
+      """
+      no
+      """
+
+    When I run `wp option get woocommerce_placeholder_image`
+    Then STDOUT should be:
+      """
+      foo.jpg
+      """
+
+    When I run `wp option get woocommerce_weight_unit`
+    Then STDOUT should be:
+      """
+      kg
+      """
+
+    When I run `wp option get woocommerce_dimension_unit`
+    Then STDOUT should be:
+      """
+      cm
+      """
+
+    When I run `wp option get woocommerce_enable_reviews`
+    Then STDOUT should be:
+      """
+      yes
+      """
+
+    When I run `wp option get woocommerce_review_rating_verification_label`
+    Then STDOUT should be:
+      """
+      no
+      """
+
+    When I run `wp option get woocommerce_review_rating_verification_required`
+    Then STDOUT should be:
+      """
+      yes
+      """
+
+    When I run `wp option get woocommerce_enable_review_rating`
+    Then STDOUT should be:
+      """
+      yes
+      """
+
+    When I run `wp option get woocommerce_review_rating_required`
+    Then STDOUT should be:
+      """
+      no
+      """
+
+    When I run `wp option get woocommerce_manage_stock`
+    Then STDOUT should be:
+      """
+      yes
+      """
+
+    When I run `wp option get woocommerce_hold_stock_minutes`
+    Then STDOUT should be:
+      """
+      5
+      """
+
+    When I run `wp option get woocommerce_notify_low_stock`
+    Then STDOUT should be:
+      """
+      yes
+      """
+
+    When I run `wp option get woocommerce_notify_no_stock`
+    Then STDOUT should be:
+      """
+      yes
+      """
+
+    When I run `wp option get woocommerce_stock_email_recipient`
+    Then STDOUT should be:
+      """
+      example@example.com
+      """
+
+    When I run `wp option get woocommerce_notify_low_stock_amount`
+    Then STDOUT should be:
+      """
+      5
+      """
+
+    When I run `wp option get woocommerce_notify_no_stock_amount`
+    Then STDOUT should be:
+      """
+      0
+      """
+
+    When I run `wp option get woocommerce_hide_out_of_stock_items`
+    Then STDOUT should be:
+      """
+      no
+      """
+
+    When I run `wp option get woocommerce_stock_format`
+    Then STDOUT should be:
+      """
+      """
+
+    When I run `wp option get woocommerce_file_download_method`
+    Then STDOUT should be:
+      """
+      redirect
+      """
+
+    When I run `wp option get woocommerce_downloads_require_login`
+    Then STDOUT should be:
+      """
+      yes
+      """
+
+    When I run `wp option get woocommerce_downloads_grant_access_after_payment`
+    Then STDOUT should be:
+      """
+      yes
+      """
+
+    When I run `wp option get woocommerce_downloads_add_hash_to_filename`
+    Then STDOUT should be:
+      """
+      yes
+      """

--- a/features/woocommerce-shipping-network-settings.feature
+++ b/features/woocommerce-shipping-network-settings.feature
@@ -1,0 +1,48 @@
+Feature: WooCommerce Network Shipping Settings Region
+
+  Scenario: Impose Shipping WooCommerce Network Settings
+    Given a WP multisite install
+    And a woocommerce-network.yml file:
+      """
+      state: network
+      sites:
+        siteone:
+          title: Site one
+          active_plugins:
+            - woocommerce/woocommerce.php
+          woocommerce-shipping:
+            enable_shipping_calc: true
+            shipping_cost_requires_address: true
+            ship_to_destination: shipping
+            shipping_debug_mode: false
+      """
+
+    When I run `wp dictator impose woocommerce-network.yml`
+    Then STDOUT should not be empty
+
+    When I run `wp dictator compare woocommerce-network.yml`
+    Then STDOUT should be empty
+
+    When I run `wp --url=example.com/siteone option get woocommerce_enable_shipping_calc`
+    Then STDOUT should be:
+      """
+      yes
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_shipping_cost_requires_address`
+    Then STDOUT should be:
+      """
+      yes
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_ship_to_destination`
+    Then STDOUT should be:
+      """
+      shipping
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_shipping_debug_mode`
+    Then STDOUT should be:
+      """
+      no
+      """

--- a/features/woocommerce-shipping-site-settings.feature
+++ b/features/woocommerce-shipping-site-settings.feature
@@ -1,0 +1,43 @@
+Feature: WooCommerce Site Shipping Settings Region
+
+  Scenario: Impose Shipping WooCommerce Site Settings
+    Given a WP install
+    And a woocommerce.yml file:
+      """
+      state: site
+      woocommerce-shipping:
+        enable_shipping_calc: true
+        shipping_cost_requires_address: true
+        ship_to_destination: shipping
+        shipping_debug_mode: false
+      """
+
+    When I run `wp dictator impose woocommerce.yml`
+    Then STDOUT should not be empty
+
+    When I run `wp dictator compare woocommerce.yml`
+    Then STDOUT should be empty
+
+    When I run `wp option get woocommerce_enable_shipping_calc`
+    Then STDOUT should be:
+      """
+      yes
+      """
+
+    When I run `wp option get woocommerce_shipping_cost_requires_address`
+    Then STDOUT should be:
+      """
+      yes
+      """
+
+    When I run `wp option get woocommerce_ship_to_destination`
+    Then STDOUT should be:
+      """
+      shipping
+      """
+
+    When I run `wp option get woocommerce_shipping_debug_mode`
+    Then STDOUT should be:
+      """
+      no
+      """

--- a/features/woocommerce-tax-network-settings.feature
+++ b/features/woocommerce-tax-network-settings.feature
@@ -1,0 +1,86 @@
+Feature: WooCommerce Network Tax Settings Region
+
+  Scenario: Impose Tax WooCommerce Network Settings
+    Given a WP multisite install
+    And a woocommerce-network.yml file:
+      """
+      state: network
+      sites:
+        siteone:
+          title: Site one
+          active_plugins:
+            - woocommerce/woocommerce.php
+          woocommerce-tax:
+            prices_include_tax: true
+            tax_based_on: shipping
+            shipping_tax_class: inherit
+            tax_round_at_subtotal: false
+            tax_classes: |
+              Tax A
+              Tax B
+            tax_display_shop: incl
+            tax_display_cart: incl
+            price_display_suffix: incl. VAT
+            tax_total_display: single
+      """
+
+    When I run `wp dictator impose woocommerce-network.yml`
+    Then STDOUT should not be empty
+
+    When I run `wp dictator compare woocommerce-network.yml`
+    Then STDOUT should be empty
+
+    When I run `wp --url=example.com/siteone option get woocommerce_prices_include_tax`
+    Then STDOUT should be:
+      """
+      yes
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_tax_based_on`
+    Then STDOUT should be:
+      """
+      shipping
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_shipping_tax_class`
+    Then STDOUT should be:
+      """
+      inherit
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_tax_round_at_subtotal`
+    Then STDOUT should be:
+      """
+      no
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_tax_classes`
+    Then STDOUT should be:
+      """
+      Tax A
+      Tax B
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_tax_display_shop`
+    Then STDOUT should be:
+      """
+      incl
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_tax_display_cart`
+    Then STDOUT should be:
+      """
+      incl
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_price_display_suffix`
+    Then STDOUT should be:
+      """
+      incl. VAT
+      """
+
+    When I run `wp --url=example.com/siteone option get woocommerce_tax_total_display`
+    Then STDOUT should be:
+      """
+      single
+      """

--- a/features/woocommerce-tax-site-settings.feature
+++ b/features/woocommerce-tax-site-settings.feature
@@ -1,0 +1,81 @@
+Feature: WooCommerce Site Tax Settings Region
+
+  Scenario: Impose Tax WooCommerce Site Settings
+    Given a WP install
+    And a woocommerce.yml file:
+      """
+      state: site
+      woocommerce-tax:
+        prices_include_tax: true
+        tax_based_on: shipping
+        shipping_tax_class: inherit
+        tax_round_at_subtotal: false
+        tax_classes: |
+          Tax A
+          Tax B
+        tax_display_shop: incl
+        tax_display_cart: incl
+        price_display_suffix: incl. VAT
+        tax_total_display: single
+      """
+
+    When I run `wp dictator impose woocommerce.yml`
+    Then STDOUT should not be empty
+
+    When I run `wp dictator compare woocommerce.yml`
+    Then STDOUT should be empty
+
+    When I run `wp option get woocommerce_prices_include_tax`
+    Then STDOUT should be:
+      """
+      yes
+      """
+
+    When I run `wp option get woocommerce_tax_based_on`
+    Then STDOUT should be:
+      """
+      shipping
+      """
+
+    When I run `wp option get woocommerce_shipping_tax_class`
+    Then STDOUT should be:
+      """
+      inherit
+      """
+
+    When I run `wp option get woocommerce_tax_round_at_subtotal`
+    Then STDOUT should be:
+      """
+      no
+      """
+
+    When I run `wp option get woocommerce_tax_classes`
+    Then STDOUT should be:
+      """
+      Tax A
+      Tax B
+      """
+
+    When I run `wp option get woocommerce_tax_display_shop`
+    Then STDOUT should be:
+      """
+      incl
+      """
+
+    When I run `wp option get woocommerce_tax_display_cart`
+    Then STDOUT should be:
+      """
+      incl
+      """
+
+    When I run `wp option get woocommerce_price_display_suffix`
+    Then STDOUT should be:
+      """
+      incl. VAT
+      """
+
+    When I run `wp option get woocommerce_tax_total_display`
+    Then STDOUT should be:
+      """
+      single
+      """

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<ruleset name="Dictator PHPCS">
+    <description>Dictator PHPCS rules</description>
+
+    <file>.</file>
+
+    <arg value="sp"/> <!-- Show sniff and progress -->
+    <arg name="colors"/> <!-- Show results with colors. Disable if working on Windows -->
+    <arg name="basepath" value="."/> <!-- Strip the file paths down to the relevant bit -->
+    <arg name="parallel" value="8"/> <!-- Enables parallel processing when available for faster results -->
+    <config name="testVersion" value="5.6-"/>
+
+    <exclude-pattern>*/vendor/*</exclude-pattern>
+
+    <rule ref="WordPress">
+        <exclude name="Squiz.Commenting.FileComment.Missing"/>
+        <exclude name="Squiz.Commenting.ClassComment.Missing"/>
+        <exclude name="Squiz.Commenting.FileComment.MissingPackageTag"/>
+        <exclude name="WordPress.PHP.YodaConditions.NotYoda"/>
+
+        <!-- Following is due to using PSR-4 autoloading -->
+        <exclude name="WordPress.Files.FileName.NotHyphenatedLowercase"/>
+        <exclude name="WordPress.Files.FileName.InvalidClassFileName"/>
+    </rule>
+</ruleset>

--- a/src/Region/AccountsSettings.php
+++ b/src/Region/AccountsSettings.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace BoxUk\DictatorWooCommerce\Region;
+
+trait AccountsSettings {
+	/**
+	 * Schema config.
+	 *
+	 * @see https://docs.woocommerce.com/document/configuring-woocommerce-settings/#accounts-and-privacy-settings
+	 *
+	 * @var array $schema
+	 */
+	protected $accounts_settings_schema = array(
+		'_type'     => 'array',
+		'_children' => array(
+			// Guest checkout.
+			'enable_guest_checkout'                 => array(
+				'_type'         => 'bool',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			'enable_checkout_login_reminder'        => array(
+				'_type'         => 'bool',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			// Account creation.
+			'enable_signup_and_login_from_checkout' => array(
+				'_type'         => 'bool',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			'enable_myaccount_registration'         => array(
+				'_type'         => 'bool',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			'registration_generate_username'        => array(
+				'_type'         => 'bool',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			'registration_generate_password'        => array(
+				'_type'         => 'bool',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			// Account erasure requests.
+			'erasure_request_removes_order_data'    => array(
+				'_type'         => 'bool',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			'erasure_request_removes_download_data' => array(
+				'_type'         => 'bool',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			// Personal data removal.
+			'allow_bulk_remove_personal_data'       => array(
+				'_type'         => 'bool',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			// Privacy policy.
+			'registration_privacy_policy_text'      => array(
+				'_type'         => 'text',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			'checkout_privacy_policy_text'          => array(
+				'_type'         => 'text',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			// Personal data retention.
+			'delete_inactive_accounts'              => array(
+				'_type'         => 'array',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			'trash_pending_orders'                  => array(
+				'_type'         => 'array',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			'trash_failed_orders'                   => array(
+				'_type'         => 'array',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			'trash_cancelled_orders'                => array(
+				'_type'         => 'array',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			'anonymize_completed_orders'            => array(
+				'_type'         => 'array',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+		),
+	);
+}

--- a/src/Region/AdvancedSettings.php
+++ b/src/Region/AdvancedSettings.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace BoxUk\DictatorWooCommerce\Region;
+
+trait AdvancedSettings {
+	/**
+	 * Schema config.
+	 *
+	 * @see https://docs.woocommerce.com/document/configuring-woocommerce-settings/#section-25 (?!)
+	 *
+	 * @var array $schema
+	 */
+	protected $advanced_settings_schema = array(
+		'_type'     => 'array',
+		'_children' => array(
+			// Page setup.
+			'cart_page_id'                             => array(
+				'_type'         => 'numeric',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			'checkout_page_id'                         => array(
+				'_type'         => 'numeric',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			'myaccount_page_id'                        => array(
+				'_type'         => 'numeric',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			'terms_page_id'                            => array(
+				'_type'         => 'numeric',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			'force_ssl_checkout'                       => array(
+				'_type'         => 'bool',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			'unforce_ssl_checkout'                     => array(
+				'_type'         => 'bool',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			// Checkout endpoints.
+			'checkout_pay_endpoint'                    => array(
+				'_type'         => 'text',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			'checkout_order_received_endpoint'         => array(
+				'_type'         => 'text',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			'myaccount_add_payment_method_endpoint'    => array(
+				'_type'         => 'text',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			'myaccount_delete_payment_method_endpoint' => array(
+				'_type'         => 'text',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			'myaccount_set_default_payment_method_endpoint' => array(
+				'_type'         => 'text',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			// Account endpoints.
+			'myaccount_orders_endpoint'                => array(
+				'_type'         => 'text',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			'myaccount_view_order_endpoint'            => array(
+				'_type'         => 'text',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			'myaccount_downloads_endpoint'             => array(
+				'_type'         => 'text',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			'myaccount_edit_account_endpoint'          => array(
+				'_type'         => 'text',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			'myaccount_edit_address_endpoint'          => array(
+				'_type'         => 'text',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			'myaccount_payment_methods_endpoint'       => array(
+				'_type'         => 'text',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			'myaccount_lost_password_endpoint'         => array(
+				'_type'         => 'text',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			'logout_endpoint'                          => array(
+				'_type'         => 'text',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			// Legacy API.
+			'api_enabled'                              => array(
+				'_type'         => 'bool',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			// WooCommerce.com Usage Tracking.
+			'allow_tracking'                           => array(
+				'_type'         => 'bool',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			// WooCommerce.com Marketplace suggestions.
+			'show_marketplace_suggestions'             => array(
+				'_type'         => 'bool',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+		),
+	);
+}

--- a/src/Region/EmailSettings.php
+++ b/src/Region/EmailSettings.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace BoxUk\DictatorWooCommerce\Region;
+
+trait EmailSettings {
+	/**
+	 * Schema config.
+	 *
+	 * @see https://docs.woocommerce.com/document/configuring-woocommerce-settings/#email-settings
+	 *
+	 * @var array $schema
+	 */
+	protected $email_settings_schema = array(
+		'_type'     => 'array',
+		'_children' => array(
+			// Email sender options.
+			'email_from_name'              => array(
+				'_type'         => 'text',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			'email_from_address'           => array(
+				'_type'         => 'email',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			// Email template.
+			'email_header_image'           => array(
+				'_type'         => 'text',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			'email_footer_text'            => array(
+				'_type'         => 'text',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			'email_base_color'             => array(
+				'_type'         => 'text',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			'email_background_color'       => array(
+				'_type'         => 'text',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			'email_body_background_color'  => array(
+				'_type'         => 'text',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			'email_text_color'             => array(
+				'_type'         => 'text',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			// Store management insights.
+			'merchant_email_notifications' => array(
+				'_type'         => 'bool',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+		),
+	);
+}

--- a/src/Region/GeneralSettings.php
+++ b/src/Region/GeneralSettings.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace BoxUk\DictatorWooCommerce\Region;
+
+trait GeneralSettings {
+	/**
+	 * Schema config.
+	 *
+	 * @see https://docs.woocommerce.com/document/configuring-woocommerce-settings/#general-settings
+	 *
+	 * @var array $schema
+	 */
+	protected $general_settings_schema = array(
+		'_type'     => 'array',
+		'_children' => array(
+			// Store Address.
+			'store_address'               => array(
+				'_type'         => 'text',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			'store_address_2'             => array(
+				'_type'         => 'text',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			'store_city'                  => array(
+				'_type'         => 'text',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			'default_country'             => array(
+				'_type'         => 'text',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			'store_postcode'              => array(
+				'_type'         => 'text',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			// General options.
+			'allowed_countries'           => array(
+				'_type'         => 'text',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			'specific_allowed_countries'  => array(
+				'_type'         => 'array',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			'ship_to_countries'           => array(
+				'_type'         => 'text',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			'specific_ship_to_countries'  => array(
+				'_type'         => 'array',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			'default_customer_address'    => array(
+				'_type'         => 'text',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			'calc_taxes'                  => array(
+				'_type'         => 'bool',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			'enable_coupons'              => array(
+				'_type'         => 'bool',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			'calc_discounts_sequentially' => array(
+				'_type'         => 'bool',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			// Currency options.
+			'currency'                    => array(
+				'_type'         => 'text',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			'currency_pos'                => array(
+				'_type'         => 'text',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			'price_thousand_sep'          => array(
+				'_type'         => 'text',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			'price_decimal_sep'           => array(
+				'_type'         => 'text',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			'price_num_decimals'          => array(
+				'_type'         => 'numeric',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+		),
+	);
+}

--- a/src/Region/ProductSettings.php
+++ b/src/Region/ProductSettings.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace BoxUk\DictatorWooCommerce\Region;
+
+trait ProductSettings {
+	/**
+	 * Schema config.
+	 *
+	 * @see https://docs.woocommerce.com/document/configuring-woocommerce-settings/#product-settings
+	 *
+	 * @var array $schema
+	 */
+	protected $product_settings_schema = array(
+		'_type'     => 'array',
+		'_children' => array(
+			// General - Shop pages.
+			'shop_page_id'                         => array(
+				'_type'         => 'numeric',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			'cart_redirect_after_add'              => array(
+				'_type'         => 'bool',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			'enable_ajax_add_to_cart'              => array(
+				'_type'         => 'bool',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			'placeholder_image'                    => array(
+				'_type'         => 'text',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			// General - Measurements.
+			'weight_unit'                          => array(
+				'_type'         => 'text',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			'dimension_unit'                       => array(
+				'_type'         => 'text',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			// General - Reviews.
+			'enable_reviews'                       => array(
+				'_type'         => 'bool',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			'review_rating_verification_label'     => array(
+				'_type'         => 'bool',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			'review_rating_verification_required'  => array(
+				'_type'         => 'bool',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			'enable_review_rating'                 => array(
+				'_type'         => 'bool',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			'review_rating_required'               => array(
+				'_type'         => 'bool',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			// Inventory.
+			'manage_stock'                         => array(
+				'_type'         => 'bool',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			'hold_stock_minutes'                   => array(
+				'_type'         => 'numeric',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			'notify_low_stock'                     => array(
+				'_type'         => 'bool',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			'notify_no_stock'                      => array(
+				'_type'         => 'bool',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			'stock_email_recipient'                => array(
+				'_type'         => 'email',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			'notify_low_stock_amount'              => array(
+				'_type'         => 'numeric',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			'notify_no_stock_amount'               => array(
+				'_type'         => 'numeric',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			'hide_out_of_stock_items'              => array(
+				'_type'         => 'bool',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			'stock_format'                         => array(
+				'_type'         => 'text',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			// Downloadable Products.
+			'file_download_method'                 => array(
+				'_type'         => 'text',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			'downloads_require_login'              => array(
+				'_type'         => 'bool',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			'downloads_grant_access_after_payment' => array(
+				'_type'         => 'bool',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			'downloads_add_hash_to_filename'       => array(
+				'_type'         => 'bool',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+		),
+	);
+}

--- a/src/Region/ShippingSettings.php
+++ b/src/Region/ShippingSettings.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace BoxUk\DictatorWooCommerce\Region;
+
+trait ShippingSettings {
+	/**
+	 * Schema config.
+	 *
+	 * @see https://docs.woocommerce.com/document/configuring-woocommerce-settings/#shipping-settings
+	 *
+	 * @var array $schema
+	 */
+	protected $shipping_settings_schema = array(
+		'_type'     => 'array',
+		'_children' => array(
+			// Shipping options.
+			'enable_shipping_calc'           => array(
+				'_type'         => 'bool',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			'shipping_cost_requires_address' => array(
+				'_type'         => 'bool',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			'ship_to_destination'            => array(
+				'_type'         => 'text',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			'shipping_debug_mode'            => array(
+				'_type'         => 'bool',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+		),
+	);
+}

--- a/src/Region/SiteAccountsSettings.php
+++ b/src/Region/SiteAccountsSettings.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace BoxUk\DictatorWooCommerce\Region;
+
+use Dictator;
+use Dictator\Regions\Region;
+
+final class SiteAccountsSettings extends Region {
+	use Util;
+	use AccountsSettings;
+
+	/**
+	 * Return our schema.
+	 *
+	 * @return array
+	 */
+	public function get_schema() {
+		return $this->accounts_settings_schema;
+	}
+
+	/**
+	 * Sets data.
+	 *
+	 * @param null  $_ Unused.
+	 * @param mixed $options Options to impose.
+	 * @return bool
+	 */
+	public function impose( $_, $options ) {
+		foreach ( $options as $option => $content ) {
+			switch ( $option ) {
+				case 'enable_guest_checkout':
+				case 'enable_checkout_login_reminder':
+				case 'enable_signup_and_login_from_checkout':
+				case 'enable_myaccount_registration':
+				case 'registration_generate_username':
+				case 'registration_generate_password':
+				case 'erasure_request_removes_order_data':
+				case 'erasure_request_removes_download_data':
+				case 'allow_bulk_remove_personal_data':
+					$content = $content === true ? 'yes' : 'no';
+			}
+			update_option( self::normalise_option( $option ), $content );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Retrieves option name.
+	 *
+	 * @param string $name Option name.
+	 * @return mixed|void
+	 */
+	public function get( string $name ) {
+		switch ( $name ) {
+			case 'delete_inactive_accounts':
+			case 'trash_pending_orders':
+			case 'trash_failed_orders':
+			case 'trash_cancelled_orders':
+			case 'anonymize_completed_orders':
+				return get_option( self::normalise_option( $name ), array() );
+			case 'enable_checkout_login_reminder':
+			case 'enable_signup_and_login_from_checkout':
+			case 'enable_myaccount_registration':
+			case 'erasure_request_removes_order_data':
+			case 'erasure_request_removes_download_data':
+			case 'allow_bulk_remove_personal_data':
+				$yes_or_no = get_option( self::normalise_option( $name ), 'no' );
+				return $yes_or_no === 'yes';
+			case 'enable_guest_checkout':
+			case 'registration_generate_username':
+			case 'registration_generate_password':
+				$yes_or_no = get_option( self::normalise_option( $name ), 'yes' );
+				return $yes_or_no === 'yes';
+		}
+
+		return get_option( self::normalise_option( $name ) );
+	}
+
+	/**
+	 * Calculates diff.
+	 *
+	 * @return array
+	 */
+	public function get_differences() {
+		$result = array(
+			'dictated' => $this->get_imposed_data(),
+			'current'  => $this->get_current_data(),
+		);
+
+		if ( Dictator::array_diff_recursive( $result['dictated'], $result['current'] ) ) {
+			return array( 'option' => $result );
+		}
+
+		return array();
+	}
+}

--- a/src/Region/SiteAdvancedSettings.php
+++ b/src/Region/SiteAdvancedSettings.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace BoxUk\DictatorWooCommerce\Region;
+
+use Dictator;
+use Dictator\Regions\Region;
+
+final class SiteAdvancedSettings extends Region {
+	use Util;
+	use AdvancedSettings;
+
+	/**
+	 * Return our schema.
+	 *
+	 * @return array
+	 */
+	public function get_schema() {
+		return $this->advanced_settings_schema;
+	}
+
+	/**
+	 * Sets data.
+	 *
+	 * @param null  $_ Unused.
+	 * @param mixed $options Options to impose.
+	 * @return bool
+	 */
+	public function impose( $_, $options ) {
+		foreach ( $options as $option => $content ) {
+			switch ( $option ) {
+				case 'force_ssl_checkout':
+				case 'unforce_ssl_checkout':
+				case 'api_enabled':
+				case 'allow_tracking':
+				case 'show_marketplace_suggestions':
+					$content = $content === true ? 'yes' : 'no';
+			}
+			update_option( self::normalise_option( $option ), $content );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Retrieves option name.
+	 *
+	 * @param string $name Option name.
+	 * @return mixed|void
+	 */
+	public function get( string $name ) {
+		switch ( $name ) {
+			case 'force_ssl_checkout':
+			case 'unforce_ssl_checkout':
+			case 'api_enabled':
+			case 'allow_tracking':
+				$yes_or_no = get_option( self::normalise_option( $name ), 'no' );
+				return $yes_or_no === 'yes';
+			case 'show_marketplace_suggestions':
+				$yes_or_no = get_option( self::normalise_option( $name ), 'yes' );
+				return $yes_or_no === 'yes';
+		}
+
+		return get_option( self::normalise_option( $name ) );
+	}
+
+	/**
+	 * Calculates diff.
+	 *
+	 * @return array
+	 */
+	public function get_differences() {
+		$result = array(
+			'dictated' => $this->get_imposed_data(),
+			'current'  => $this->get_current_data(),
+		);
+
+		if ( Dictator::array_diff_recursive( $result['dictated'], $result['current'] ) ) {
+			return array( 'option' => $result );
+		}
+
+		return array();
+	}
+}

--- a/src/Region/SiteEmailSettings.php
+++ b/src/Region/SiteEmailSettings.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace BoxUk\DictatorWooCommerce\Region;
+
+use Dictator;
+use Dictator\Regions\Region;
+
+final class SiteEmailSettings extends Region {
+	use Util;
+	use EmailSettings;
+
+	/**
+	 * Return our schema.
+	 *
+	 * @return array
+	 */
+	public function get_schema() {
+		return $this->email_settings_schema;
+	}
+
+	/**
+	 * Sets data.
+	 *
+	 * @param null  $_ Unused.
+	 * @param mixed $options Options to impose.
+	 * @return bool
+	 */
+	public function impose( $_, $options ) {
+		foreach ( $options as $option => $content ) {
+			switch ( $option ) {
+				case 'merchant_email_notifications':
+					$content = $content === true ? 'yes' : 'no';
+			}
+			update_option( self::normalise_option( $option ), $content );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Retrieves option name.
+	 *
+	 * @param string $name Option name.
+	 * @return mixed|void
+	 */
+	public function get( string $name ) {
+		switch ( $name ) {
+			case 'merchant_email_notifications':
+				$yes_or_no = get_option( self::normalise_option( $name ), 'no' );
+				return $yes_or_no === 'yes';
+		}
+
+		return get_option( self::normalise_option( $name ) );
+	}
+
+	/**
+	 * Calculates diff.
+	 *
+	 * @return array
+	 */
+	public function get_differences() {
+		$result = array(
+			'dictated' => $this->get_imposed_data(),
+			'current'  => $this->get_current_data(),
+		);
+
+		if ( Dictator::array_diff_recursive( $result['dictated'], $result['current'] ) ) {
+			return array( 'option' => $result );
+		}
+
+		return array();
+	}
+}

--- a/src/Region/SiteGeneralSettings.php
+++ b/src/Region/SiteGeneralSettings.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace BoxUk\DictatorWooCommerce\Region;
+
+use Dictator;
+use Dictator\Regions\Region;
+
+final class SiteGeneralSettings extends Region {
+	use Util;
+	use GeneralSettings;
+
+	/**
+	 * Return our schema.
+	 *
+	 * @return array
+	 */
+	public function get_schema() {
+		return $this->general_settings_schema;
+	}
+
+	/**
+	 * Sets data.
+	 *
+	 * @param null  $_ Unused.
+	 * @param mixed $options Options to impose.
+	 * @return bool
+	 */
+	public function impose( $_, $options ) {
+		foreach ( $options as $option => $content ) {
+			switch ( $option ) {
+				case 'calc_taxes':
+				case 'enable_coupons':
+				case 'calc_discounts_sequentially':
+					$content = $content === true ? 'yes' : 'no';
+			}
+			update_option( self::normalise_option( $option ), $content );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Retrieves option name.
+	 *
+	 * @param string $name Option name.
+	 * @return mixed|void
+	 */
+	public function get( string $name ) {
+		switch ( $name ) {
+			case 'specific_allowed_countries':
+			case 'specific_ship_to_countries':
+				return get_option( self::normalise_option( $name ), array() );
+			case 'calc_taxes':
+			case 'calc_discounts_sequentially':
+				$yes_or_no = get_option( self::normalise_option( $name ), 'no' );
+				return $yes_or_no === 'yes';
+			case 'enable_coupons':
+				$yes_or_no = get_option( self::normalise_option( $name ), 'yes' );
+				return $yes_or_no === 'yes';
+		}
+
+		return get_option( self::normalise_option( $name ) );
+	}
+
+	/**
+	 * Calculates diff.
+	 *
+	 * @return array
+	 */
+	public function get_differences() {
+		$result = array(
+			'dictated' => $this->get_imposed_data(),
+			'current'  => $this->get_current_data(),
+		);
+
+		if ( Dictator::array_diff_recursive( $result['dictated'], $result['current'] ) ) {
+			return array( 'option' => $result );
+		}
+
+		return array();
+	}
+}

--- a/src/Region/SiteProductSettings.php
+++ b/src/Region/SiteProductSettings.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace BoxUk\DictatorWooCommerce\Region;
+
+use Dictator;
+use Dictator\Regions\Region;
+
+final class SiteProductSettings extends Region {
+	use Util;
+	use ProductSettings;
+
+	/**
+	 * Return our schema.
+	 *
+	 * @return array
+	 */
+	public function get_schema() {
+		return $this->product_settings_schema;
+	}
+
+	/**
+	 * Sets data.
+	 *
+	 * @param null  $_ Unused.
+	 * @param mixed $options Options to impose.
+	 * @return bool
+	 */
+	public function impose( $_, $options ) {
+		foreach ( $options as $option => $content ) {
+			switch ( $option ) {
+				case 'cart_redirect_after_add':
+				case 'enable_ajax_add_to_cart':
+				case 'enable_reviews':
+				case 'review_rating_verification_label':
+				case 'review_rating_verification_required':
+				case 'enable_review_rating':
+				case 'review_rating_required':
+				case 'manage_stock':
+				case 'notify_low_stock':
+				case 'notify_no_stock':
+				case 'hide_out_of_stock_items':
+				case 'downloads_require_login':
+				case 'downloads_grant_access_after_payment':
+				case 'downloads_add_hash_to_filename':
+					$content = $content === true ? 'yes' : 'no';
+			}
+			update_option( self::normalise_option( $option ), $content );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Retrieves option name.
+	 *
+	 * @param string $name Option name.
+	 * @return mixed|void
+	 */
+	public function get( string $name ) {
+		switch ( $name ) {
+			case 'cart_redirect_after_add':
+			case 'review_rating_verification_required':
+			case 'hide_out_of_stock_items':
+			case 'downloads_require_login':
+				$yes_or_no = get_option( self::normalise_option( $name ), 'no' );
+				return $yes_or_no === 'yes';
+			case 'enable_ajax_add_to_cart':
+			case 'enable_reviews':
+			case 'review_rating_verification_label':
+			case 'enable_review_rating':
+			case 'review_rating_required':
+			case 'manage_stock':
+			case 'notify_low_stock':
+			case 'notify_no_stock':
+			case 'downloads_grant_access_after_payment':
+			case 'downloads_add_hash_to_filename':
+				$yes_or_no = get_option( self::normalise_option( $name ), 'yes' );
+				return $yes_or_no === 'yes';
+		}
+
+		return get_option( self::normalise_option( $name ) );
+	}
+
+	/**
+	 * Calculates diff.
+	 *
+	 * @return array
+	 */
+	public function get_differences() {
+		$result = array(
+			'dictated' => $this->get_imposed_data(),
+			'current'  => $this->get_current_data(),
+		);
+
+		if ( Dictator::array_diff_recursive( $result['dictated'], $result['current'] ) ) {
+			return array( 'option' => $result );
+		}
+
+		return array();
+	}
+}

--- a/src/Region/SiteShippingSettings.php
+++ b/src/Region/SiteShippingSettings.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace BoxUk\DictatorWooCommerce\Region;
+
+use Dictator;
+use Dictator\Regions\Region;
+
+final class SiteShippingSettings extends Region {
+	use Util;
+	use ShippingSettings;
+
+	/**
+	 * Return our schema.
+	 *
+	 * @return array
+	 */
+	public function get_schema() {
+		return $this->shipping_settings_schema;
+	}
+
+	/**
+	 * Sets data.
+	 *
+	 * @param null  $_ Unused.
+	 * @param mixed $options Options to impose.
+	 * @return bool
+	 */
+	public function impose( $_, $options ) {
+		foreach ( $options as $option => $content ) {
+			switch ( $option ) {
+				case 'enable_shipping_calc':
+				case 'shipping_cost_requires_address':
+				case 'shipping_debug_mode':
+					$content = $content === true ? 'yes' : 'no';
+			}
+			update_option( self::normalise_option( $option ), $content );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Retrieves option name.
+	 *
+	 * @param string $name Option name.
+	 * @return mixed|void
+	 */
+	public function get( string $name ) {
+		switch ( $name ) {
+			case 'shipping_cost_requires_address':
+			case 'shipping_debug_mode':
+				$yes_or_no = get_option( self::normalise_option( $name ), 'no' );
+				return $yes_or_no === 'yes';
+			case 'enable_shipping_calc':
+				$yes_or_no = get_option( self::normalise_option( $name ), 'yes' );
+				return $yes_or_no === 'yes';
+		}
+
+		return get_option( self::normalise_option( $name ) );
+	}
+
+	/**
+	 * Calculates diff.
+	 *
+	 * @return array
+	 */
+	public function get_differences() {
+		$result = array(
+			'dictated' => $this->get_imposed_data(),
+			'current'  => $this->get_current_data(),
+		);
+
+		if ( Dictator::array_diff_recursive( $result['dictated'], $result['current'] ) ) {
+			return array( 'option' => $result );
+		}
+
+		return array();
+	}
+}

--- a/src/Region/SiteTaxSettings.php
+++ b/src/Region/SiteTaxSettings.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace BoxUk\DictatorWooCommerce\Region;
+
+use Dictator;
+use Dictator\Regions\Region;
+
+final class SiteTaxSettings extends Region {
+	use Util;
+	use TaxSettings;
+
+	/**
+	 * Return our schema.
+	 *
+	 * @return array
+	 */
+	public function get_schema() {
+		return $this->tax_settings_schema;
+	}
+
+	/**
+	 * Sets data.
+	 *
+	 * @param null  $_ Unused.
+	 * @param mixed $options Options to impose.
+	 * @return bool
+	 */
+	public function impose( $_, $options ) {
+		foreach ( $options as $option => $content ) {
+			switch ( $option ) {
+				case 'prices_include_tax':
+				case 'tax_round_at_subtotal':
+					$content = $content === true ? 'yes' : 'no';
+			}
+			update_option( self::normalise_option( $option ), $content );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Retrieves option name.
+	 *
+	 * @param string $name Option name.
+	 * @return mixed|void
+	 */
+	public function get( string $name ) {
+		switch ( $name ) {
+			case 'prices_include_tax':
+			case 'tax_round_at_subtotal':
+				$yes_or_no = get_option( self::normalise_option( $name ), 'no' );
+				return $yes_or_no === 'yes';
+		}
+
+		return get_option( self::normalise_option( $name ) );
+	}
+
+	/**
+	 * Calculates diff.
+	 *
+	 * @return array
+	 */
+	public function get_differences() {
+		$result = array(
+			'dictated' => $this->get_imposed_data(),
+			'current'  => $this->get_current_data(),
+		);
+
+		if ( Dictator::array_diff_recursive( $result['dictated'], $result['current'] ) ) {
+			return array( 'option' => $result );
+		}
+
+		return array();
+	}
+}

--- a/src/Region/TaxSettings.php
+++ b/src/Region/TaxSettings.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace BoxUk\DictatorWooCommerce\Region;
+
+trait TaxSettings {
+	/**
+	 * Schema config.
+	 *
+	 * @see https://docs.woocommerce.com/document/configuring-woocommerce-settings/#tax-settings
+	 *
+	 * @var array $schema
+	 */
+	protected $tax_settings_schema = array(
+		'_type'     => 'array',
+		'_children' => array(
+			// Tax options.
+			'prices_include_tax'    => array(
+				'_type'         => 'bool',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			'tax_based_on'          => array(
+				'_type'         => 'text',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			'shipping_tax_class'    => array(
+				'_type'         => 'text',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			'tax_round_at_subtotal' => array(
+				'_type'         => 'bool',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			'tax_classes'           => array(
+				'_type'         => 'text',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			'tax_display_shop'      => array(
+				'_type'         => 'text',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			'tax_display_cart'      => array(
+				'_type'         => 'text',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			'price_display_suffix'  => array(
+				'_type'         => 'text',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+			'tax_total_display'     => array(
+				'_type'         => 'text',
+				'_required'     => false,
+				'_get_callback' => 'get',
+			),
+		),
+	);
+}

--- a/src/Region/Util.php
+++ b/src/Region/Util.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace BoxUk\DictatorWooCommerce\Region;
+
+trait Util {
+	/**
+	 * Normalises option by adding WooCommerce prefix if not present.
+	 *
+	 * @param string $option Option name.
+	 *
+	 * @return string
+	 */
+	public static function normalise_option( string $option ): string {
+		if ( strpos( $option, 'woocommerce_' ) !== 0 ) {
+			$option = 'woocommerce_' . $option;
+		}
+
+		return $option;
+	}
+}

--- a/src/Region/WoocommerceNetworkSites.php
+++ b/src/Region/WoocommerceNetworkSites.php
@@ -1,0 +1,274 @@
+<?php
+
+namespace BoxUk\DictatorWooCommerce\Region;
+
+use Dictator\Regions\Network_Sites;
+
+final class WoocommerceNetworkSites extends Network_Sites {
+	use Util;
+	use GeneralSettings;
+	use ProductSettings;
+	use TaxSettings;
+	use ShippingSettings;
+	use AccountsSettings;
+	use EmailSettings;
+	use AdvancedSettings;
+
+	/**
+	 * Return our schema.
+	 *
+	 * @return array
+	 */
+	public function get_schema() {
+		$parent_schema = parent::get_schema();
+		// General.
+		$parent_schema['_prototype']['_children']['woocommerce-general'] = array(
+			'_type'     => $this->general_settings_schema['_type'],
+			'_children' => $this->general_settings_schema['_children'],
+		);
+
+		// Product.
+		$parent_schema['_prototype']['_children']['woocommerce-product'] = array(
+			'_type'     => $this->product_settings_schema['_type'],
+			'_children' => $this->product_settings_schema['_children'],
+		);
+
+		// Tax.
+		$parent_schema['_prototype']['_children']['woocommerce-tax'] = array(
+			'_type'     => $this->tax_settings_schema['_type'],
+			'_children' => $this->tax_settings_schema['_children'],
+		);
+
+		// Shipping.
+		$parent_schema['_prototype']['_children']['woocommerce-shipping'] = array(
+			'_type'     => $this->shipping_settings_schema['_type'],
+			'_children' => $this->shipping_settings_schema['_children'],
+		);
+
+		// Accounts.
+		$parent_schema['_prototype']['_children']['woocommerce-accounts'] = array(
+			'_type'     => $this->accounts_settings_schema['_type'],
+			'_children' => $this->accounts_settings_schema['_children'],
+		);
+
+		// Email.
+		$parent_schema['_prototype']['_children']['woocommerce-email'] = array(
+			'_type'     => $this->email_settings_schema['_type'],
+			'_children' => $this->email_settings_schema['_children'],
+		);
+
+		// Advanced.
+		$parent_schema['_prototype']['_children']['woocommerce-advanced'] = array(
+			'_type'     => $this->advanced_settings_schema['_type'],
+			'_children' => $this->advanced_settings_schema['_children'],
+		);
+
+		$this->schema = $parent_schema;
+
+		return $this->schema;
+	}
+
+	/**
+	 * Impose some state data onto a region. Use parent unless an option has a woocommerce prefix.
+	 *
+	 * @param string $key Site slug.
+	 * @param array  $value Site data.
+	 * @return true|WP_Error
+	 */
+	public function impose( $key, $value ) {
+		$site = $this->get_site( $key );
+		if ( ! $site ) {
+			$site = $this->create_site( $key, $value );
+			if ( is_wp_error( $site ) ) {
+				return $site;
+			}
+		}
+		switch_to_blog( $site->blog_id );
+		foreach ( $value as $option => $content ) {
+			if ( strpos( $option, 'woocommerce' ) !== 0 ) {
+				parent::impose( $key, array( $option => $content ) );
+				continue;
+			}
+
+			switch ( $option ) {
+				case 'woocommerce-general':
+					foreach ( $content as $woo_general_field => $woo_general_value ) {
+						switch ( $woo_general_field ) {
+							case 'calc_taxes':
+							case 'enable_coupons':
+							case 'calc_discounts_sequentially':
+								$woo_general_value = $woo_general_value === true ? 'yes' : 'no';
+								break;
+						}
+						update_option( self::normalise_option( $woo_general_field ), $woo_general_value );
+					}
+					break;
+				case 'woocommerce-product':
+					foreach ( $content as $woo_product_field => $woo_product_value ) {
+						switch ( $woo_product_field ) {
+							case 'cart_redirect_after_add':
+							case 'enable_ajax_add_to_cart':
+							case 'enable_reviews':
+							case 'review_rating_verification_label':
+							case 'review_rating_verification_required':
+							case 'enable_review_rating':
+							case 'review_rating_required':
+							case 'manage_stock':
+							case 'notify_low_stock':
+							case 'notify_no_stock':
+							case 'hide_out_of_stock_items':
+							case 'downloads_require_login':
+							case 'downloads_grant_access_after_payment':
+							case 'downloads_add_hash_to_filename':
+								$woo_product_value = $woo_product_value === true ? 'yes' : 'no';
+								break;
+						}
+						update_option( self::normalise_option( $woo_product_field ), $woo_product_value );
+					}
+					break;
+				case 'woocommerce-tax':
+					foreach ( $content as $woo_tax_field => $woo_tax_value ) {
+						switch ( $woo_tax_field ) {
+							case 'prices_include_tax':
+							case 'tax_round_at_subtotal':
+								$woo_tax_value = $woo_tax_value === true ? 'yes' : 'no';
+								break;
+						}
+						update_option( self::normalise_option( $woo_tax_field ), $woo_tax_value );
+					}
+					break;
+				case 'woocommerce-shipping':
+					foreach ( $content as $woo_shipping_field => $woo_shipping_value ) {
+						switch ( $woo_shipping_field ) {
+							case 'enable_shipping_calc':
+							case 'shipping_cost_requires_address':
+							case 'shipping_debug_mode':
+								$woo_shipping_value = $woo_shipping_value === true ? 'yes' : 'no';
+								break;
+						}
+						update_option( self::normalise_option( $woo_shipping_field ), $woo_shipping_value );
+					}
+					break;
+				case 'woocommerce-accounts':
+					foreach ( $content as $woo_accounts_field => $woo_accounts_value ) {
+						switch ( $woo_accounts_field ) {
+							case 'enable_guest_checkout':
+							case 'enable_checkout_login_reminder':
+							case 'enable_signup_and_login_from_checkout':
+							case 'enable_myaccount_registration':
+							case 'registration_generate_username':
+							case 'registration_generate_password':
+							case 'erasure_request_removes_order_data':
+							case 'erasure_request_removes_download_data':
+							case 'allow_bulk_remove_personal_data':
+								$woo_accounts_value = $woo_accounts_value === true ? 'yes' : 'no';
+								break;
+						}
+						update_option( self::normalise_option( $woo_accounts_field ), $woo_accounts_value );
+					}
+					break;
+				case 'woocommerce-email':
+					foreach ( $content as $woo_email_field => $woo_email_value ) {
+						switch ( $woo_email_field ) {
+							case 'merchant_email_notifications':
+								$woo_email_value = $woo_email_value === true ? 'yes' : 'no';
+								break;
+						}
+						update_option( self::normalise_option( $woo_email_field ), $woo_email_value );
+					}
+					break;
+				case 'woocommerce-advanced':
+					foreach ( $content as $woo_adv_field => $woo_adv_value ) {
+						switch ( $woo_adv_field ) {
+							case 'force_ssl_checkout':
+							case 'unforce_ssl_checkout':
+							case 'api_enabled':
+							case 'allow_tracking':
+							case 'show_marketplace_suggestions':
+								$woo_adv_value = $woo_adv_value === true ? 'yes' : 'no';
+								break;
+						}
+						update_option( self::normalise_option( $woo_adv_field ), $woo_adv_value );
+					}
+					break;
+			}
+		}
+		restore_current_blog();
+
+		return true;
+	}
+
+	/**
+	 * Retrieves option name. This differs from the version in the trait as it switches to the relevant site first.
+	 *
+	 * @param string $name Option name.
+	 * @return mixed|void
+	 */
+	public function get( string $name ) {
+
+		$site_slug = $this->current_schema_attribute_parents[0];
+		$site      = $this->get_site( $site_slug );
+
+		switch_to_blog( $site->blog_id );
+		switch ( $name ) {
+			case 'specific_allowed_countries':
+			case 'specific_ship_to_countries':
+			case 'delete_inactive_accounts':
+			case 'trash_pending_orders':
+			case 'trash_failed_orders':
+			case 'trash_cancelled_orders':
+			case 'anonymize_completed_orders':
+				$value = get_option( self::normalise_option( $name ), array() );
+				break;
+			case 'calc_taxes':
+			case 'calc_discounts_sequentially':
+			case 'cart_redirect_after_add':
+			case 'review_rating_verification_required':
+			case 'hide_out_of_stock_items':
+			case 'downloads_require_login':
+			case 'prices_include_tax':
+			case 'tax_round_at_subtotal':
+			case 'shipping_cost_requires_address':
+			case 'shipping_debug_mode':
+			case 'enable_checkout_login_reminder':
+			case 'enable_signup_and_login_from_checkout':
+			case 'enable_myaccount_registration':
+			case 'erasure_request_removes_order_data':
+			case 'erasure_request_removes_download_data':
+			case 'allow_bulk_remove_personal_data':
+			case 'merchant_email_notifications':
+			case 'force_ssl_checkout':
+			case 'unforce_ssl_checkout':
+			case 'api_enabled':
+			case 'allow_tracking':
+				$yes_or_no = get_option( self::normalise_option( $name ), 'no' );
+				$value     = $yes_or_no === 'yes';
+				break;
+			case 'enable_coupons':
+			case 'enable_ajax_add_to_cart':
+			case 'enable_reviews':
+			case 'review_rating_verification_label':
+			case 'enable_review_rating':
+			case 'review_rating_required':
+			case 'manage_stock':
+			case 'notify_low_stock':
+			case 'notify_no_stock':
+			case 'downloads_grant_access_after_payment':
+			case 'downloads_add_hash_to_filename':
+			case 'enable_shipping_calc':
+			case 'enable_guest_checkout':
+			case 'registration_generate_username':
+			case 'registration_generate_password':
+			case 'show_marketplace_suggestions':
+				$yes_or_no = get_option( self::normalise_option( $name ), 'yes' );
+				$value     = $yes_or_no === 'yes';
+				break;
+			default:
+				$value = get_option( self::normalise_option( $name ) );
+				break;
+		}
+
+		restore_current_blog();
+		return $value;
+	}
+}

--- a/src/State/WoocommerceNetwork.php
+++ b/src/State/WoocommerceNetwork.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace BoxUk\DictatorWooCommerce\State;
+
+use BoxUk\DictatorWooCommerce\Region\WoocommerceNetworkSites;
+use Dictator\States\Network;
+
+class WoocommerceNetwork extends Network {
+	/**
+	 * Specify required regions for the state.
+	 *
+	 * @var string[]
+	 */
+	protected $woocommerce_regions = array(
+		'sites' => WoocommerceNetworkSites::class,
+	);
+
+	/**
+	 * Rather than dictate a woocommerce state, this merges with the site state to ensure we can configure woocommerce beneath site.
+	 *
+	 * @param null $yaml Yaml settings that is passed to the parent.
+	 */
+	public function __construct( $yaml = null ) {
+		parent::__construct( $yaml );
+
+		$this->regions = array_merge(
+			$this->regions,
+			$this->woocommerce_regions
+		);
+	}
+}

--- a/src/State/WoocommerceSite.php
+++ b/src/State/WoocommerceSite.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace BoxUk\DictatorWooCommerce\State;
+
+use BoxUk\DictatorWooCommerce\Region\SiteAccountsSettings;
+use BoxUk\DictatorWooCommerce\Region\SiteAdvancedSettings;
+use BoxUk\DictatorWooCommerce\Region\SiteEmailSettings;
+use BoxUk\DictatorWooCommerce\Region\SiteGeneralSettings;
+use BoxUk\DictatorWooCommerce\Region\SiteProductSettings;
+use BoxUk\DictatorWooCommerce\Region\SiteShippingSettings;
+use BoxUk\DictatorWooCommerce\Region\SiteTaxSettings;
+use Dictator\States\Site;
+
+class WoocommerceSite extends Site {
+	/**
+	 * Specify regions required for a WooCommerce Site.
+	 *
+	 * @var string[]
+	 */
+	protected $woocommerce_regions = array(
+		'woocommerce-general'  => SiteGeneralSettings::class,
+		'woocommerce-product'  => SiteProductSettings::class,
+		'woocommerce-tax'      => SiteTaxSettings::class,
+		'woocommerce-shipping' => SiteShippingSettings::class,
+		'woocommerce-accounts' => SiteAccountsSettings::class,
+		'woocommerce-email'    => SiteEmailSettings::class,
+		'woocommerce-advanced' => SiteAdvancedSettings::class,
+	);
+
+	/**
+	 * Rather than dictate a woocommerce state, this merges with the site state to ensure we can configure woocommerce beneath site.
+	 *
+	 * @param null $yaml Yaml settings that is passed to the parent.
+	 */
+	public function __construct( $yaml = null ) {
+		parent::__construct( $yaml );
+
+		$this->regions = array_merge(
+			$this->regions,
+			$this->woocommerce_regions
+		);
+	}
+}


### PR DESCRIPTION
Augments the existing site and network states rather than adds new
states as it doesn't really make sense as a state.

Due to single level of regions it feels a little clunky, in that you
need to specify each option at the same level, e.g.

`woocommerce-general`

as opposed to

```yaml
woocommerce:
  general:
```

There needs to be a bit of work in the dictator library to better
support nested regions and inherited regions and stuff, but for now this
will work.